### PR TITLE
Fix flandreas/antares#715

### DIFF
--- a/antares/shared/src/main/ch/scorpion/antares/model/addressable/Memory.kt
+++ b/antares/shared/src/main/ch/scorpion/antares/model/addressable/Memory.kt
@@ -71,17 +71,18 @@ class Memory(private val segmentSize: Int) {
 	}
 
 	private fun getSegment(address: Int): Segment {
-		val baseAddress = address / segmentSize * segmentSize
-		var segment = segments[baseAddress]
+		val segmentIdx = address / segmentSize
+		val baseAddress = segmentIdx * segmentSize
+		var segment = segments[segmentIdx]
 		if (segment == null) {
 			segment = Segment(baseAddress)
-			segments[baseAddress] = segment
+			segments[segmentIdx] = segment
 		}
 		return segment
 	}
 
     private fun hasSegment(address: Int): Boolean {
-		return segments[address / segmentSize * segmentSize] != null
+		return segments[address / segmentSize] != null
 	}
 
 	/** Holds the internal data representation of an individual cell.*/

--- a/antares/shared/src/main/ch/scorpion/antares/model/addressable/Memory.kt
+++ b/antares/shared/src/main/ch/scorpion/antares/model/addressable/Memory.kt
@@ -81,7 +81,7 @@ class Memory(private val segmentSize: Int) {
 	}
 
     private fun hasSegment(address: Int): Boolean {
-		return segments[address / segmentSize] != null
+		return segments[address / segmentSize * segmentSize] != null
 	}
 
 	/** Holds the internal data representation of an individual cell.*/

--- a/antares/shared/src/test/ch/scorpion/antares/model/addressable/MemoryTest.kt
+++ b/antares/shared/src/test/ch/scorpion/antares/model/addressable/MemoryTest.kt
@@ -191,4 +191,15 @@ class MemoryTest {
 		memory.writeComment(3, null)
 		assertNull(memory.readComment(3))
 	}
+
+	/** ---- Regression tests */
+
+	@Test
+	fun shouldNotDiscardZeros() {
+		// test for flandreas/antares#715
+		val memory = Memory(12)
+		memory.write(2055, 2055UL)
+		memory.write(2055, 0UL)
+		assertEquals(0UL, memory.read(2055))
+	}
 }


### PR DESCRIPTION
This should fix flandreas/antares#715.

The optimization that discards a zero write if no segment has been created so far used an invalid calculation of the segment address, leading to invalid optimizations.