### PR TITLE
Allow nesting of overbars

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "asciidoc.antora.enableAntoraSupport": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "asciidoc.antora.enableAntoraSupport": false
+    "asciidoc.antora.enableAntoraSupport": false,
+    "files.trimTrailingWhitespace": false
 }

--- a/base/shared/src/main/ch/scorpion/jabbah/base/richtext/RichTextParser.kt
+++ b/base/shared/src/main/ch/scorpion/jabbah/base/richtext/RichTextParser.kt
@@ -219,13 +219,13 @@ class RichTextParser(lexer: RichTextLexer) : AbstractParser(lexer) {
 	private fun overline(): StyledText {
 		eat(OVERLINE)
 
-		style = TextStyle.withOverline(style)
+		style = TextStyle.pushOverline(style)
 		val overline = if (currentToken!!.type == LPAREN) {
 			eatParen { styledText() }
 		} else {
 			singleChar()
 		}
-		style = TextStyle.withoutOverline(style)
+		style = TextStyle.popOverline(style)
 
 		return overline
 	}

--- a/base/shared/src/main/ch/scorpion/jabbah/base/richtext/RichTextSyntaxTree.kt
+++ b/base/shared/src/main/ch/scorpion/jabbah/base/richtext/RichTextSyntaxTree.kt
@@ -112,44 +112,21 @@ class StyledText(
 
 @Suppress("MemberVisibilityCanBePrivate")
 data class TextStyle(
-	val overline: Boolean,
+	val overlineLevel: Int,
 	val bold: Boolean,
 	val italic: Boolean
 ) {
 	companion object {
-		val NORMAL = TextStyle(overline = false, bold = false, false)
-		val OVERLINE = TextStyle(overline = true, bold = false, false)
-		val BOLD = TextStyle(overline = false, bold = true, false)
-		val OVERLINE_BOLD = TextStyle(overline = true, bold = true, false)
+		val NORMAL = TextStyle(overlineLevel = 0, bold = false, italic = false)
 
-		val ITALIC = TextStyle(overline = false, bold = false, true)
-		val OVERLINE_ITALIC = TextStyle(overline = true, bold = false, true)
-		val BOLD_ITALIC = TextStyle(overline = false, bold = true, true)
-		val OVERLINE_BOLD_ITALIC = TextStyle(overline = true, bold = true, true)
+		fun pushOverline(style: TextStyle) = TextStyle(style.overlineLevel + 1, style.bold, style.italic)
+		fun popOverline(style: TextStyle) = TextStyle(if (style.overlineLevel > 0) style.overlineLevel - 1 else 0, style.bold, style.italic)
 
-		fun withOverline(style: TextStyle): TextStyle = of(true, style.bold, style.italic)
-		fun withoutOverline(style: TextStyle): TextStyle = of(false, style.bold, style.italic)
+		fun withBold(style: TextStyle) = TextStyle(style.overlineLevel, true, style.italic)
+		fun withoutBold(style: TextStyle) = TextStyle(style.overlineLevel, false, style.italic)
 
-		fun withBold(style: TextStyle): TextStyle = of(style.overline, true, style.italic)
-		fun withoutBold(style: TextStyle): TextStyle = of(style.overline, false, style.italic)
-
-		fun withItalic(style: TextStyle): TextStyle = of(style.overline, style.bold, true)
-		fun withoutItalic(style: TextStyle): TextStyle = of(style.overline, style.bold, false)
-
-		fun of(overline: Boolean, bold: Boolean, italic: Boolean): TextStyle =
-			if (overline) {
-				if (bold) {
-					if (italic) OVERLINE_BOLD_ITALIC else OVERLINE_BOLD
-				} else {
-					if (italic) OVERLINE_ITALIC else OVERLINE
-				}
-			} else {
-				if (bold) {
-					if (italic) BOLD_ITALIC else BOLD
-				} else {
-					if (italic) ITALIC else NORMAL
-				}
-			}
+		fun withItalic(style: TextStyle) = TextStyle(style.overlineLevel, style.bold, true)
+		fun withoutItalic(style: TextStyle) = TextStyle(style.overlineLevel, style.bold, false)
 	}
 }
 
@@ -167,7 +144,7 @@ class StyledChunk(
 		if (style.italic) {
 			s.append(RichTextTokenType.ITALIC.id)
 		}
-		if (style.overline) {
+		if (style.overlineLevel > 0) {
 			s.append(RichTextTokenType.OVERLINE.id)
 		}
 		if (s.isNotEmpty()) {

--- a/base/shared/src/main/ch/scorpion/jabbah/base/richtext/RichTextSyntaxTree.kt
+++ b/base/shared/src/main/ch/scorpion/jabbah/base/richtext/RichTextSyntaxTree.kt
@@ -35,6 +35,11 @@ class RichText(
 			}
 		}
 	}
+
+	fun getMaxOverlineLevel() =
+		children.maxOfOrNull {
+			it.text.styledText.chunks.maxOfOrNull { it.style.overlineLevel } ?: 0
+		} ?: 0
 }
 
 class Fragment(
@@ -120,7 +125,7 @@ data class TextStyle(
 		val NORMAL = TextStyle(overlineLevel = 0, bold = false, italic = false)
 
 		fun pushOverline(style: TextStyle) = TextStyle(style.overlineLevel + 1, style.bold, style.italic)
-		fun popOverline(style: TextStyle) = TextStyle(if (style.overlineLevel > 0) style.overlineLevel - 1 else 0, style.bold, style.italic)
+		fun popOverline(style: TextStyle) = TextStyle(Math.max(style.overlineLevel - 1, 0), style.bold, style.italic)
 
 		fun withBold(style: TextStyle) = TextStyle(style.overlineLevel, true, style.italic)
 		fun withoutBold(style: TextStyle) = TextStyle(style.overlineLevel, false, style.italic)
@@ -144,7 +149,7 @@ class StyledChunk(
 		if (style.italic) {
 			s.append(RichTextTokenType.ITALIC.id)
 		}
-		if (style.overlineLevel > 0) {
+		for (i in 1 .. style.overlineLevel) {
 			s.append(RichTextTokenType.OVERLINE.id)
 		}
 		if (s.isNotEmpty()) {

--- a/base/shared/src/test/ch/scorpion/jabbah/base/richtext/RichTextParserTest.kt
+++ b/base/shared/src/test/ch/scorpion/jabbah/base/richtext/RichTextParserTest.kt
@@ -4,6 +4,7 @@ import ch.scorpion.jabbah.base.Translations
 import ch.scorpion.jabbah.base.dsl.assertAST
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class RichTextParserTest {
 
@@ -208,6 +209,28 @@ class RichTextParserTest {
 			-- ^
 			--- !(123)
 		""".trimIndent())
+	}
+
+	@Test
+	fun shouldParseNestedOverline() {
+		val ast = RichTextParser("!(A !(!B) !C) !D").parse()
+		assertAST(
+			ast, """
+			Compound
+			- Fragment
+			-- -
+			--- !(A )
+			--- !!!(B)
+			--- !( )
+			--- !!(C)
+			- Fragment
+			-- -
+			---  
+			- Fragment
+			-- -
+			--- !(D)
+		""".trimIndent())
+		assertEquals(ast.getMaxOverlineLevel(), 3)
 	}
 
 	@Test

--- a/base/shared/src/test/ch/scorpion/jabbah/base/richtext/StyledChunkTest.kt
+++ b/base/shared/src/test/ch/scorpion/jabbah/base/richtext/StyledChunkTest.kt
@@ -9,7 +9,7 @@ class StyledChunkTest {
 
 	@Test
 	fun shouldSplitWords() {
-		val chunk = StyledChunk(TextLocation(0, 0, 0), "This is a text.", TextStyle.OVERLINE_BOLD)
+		val chunk = StyledChunk(TextLocation(0, 0, 0), "This is a text.", TextStyle(overlineLevel = 1, bold = true, italic = false))
 		val words = chunk.splitWords()
 
 		assertEquals(4, words.size)
@@ -17,6 +17,6 @@ class StyledChunkTest {
 		assertEquals("is ", words[1].text)
 		assertEquals("a ", words[2].text)
 		assertEquals("text.", words[3].text)
-		assertTrue(words.all { it.style.bold && it.style.overline })
+		assertTrue(words.all { it.style.bold && it.style.overlineLevel == 1 })
 	}
 }

--- a/doc/user-manual/english/circuits/text-style.adoc
+++ b/doc/user-manual/english/circuits/text-style.adoc
@@ -33,6 +33,8 @@ Render a text block following another text block as subscript with an caret `^` 
 
 Render a text block with an overline by using an exclamation mark `!` for single characters or `!(text)` for multi-character text.
 
+Negations can also be nested, for example `!(ENABLE !(A+B))`.
+
 **Examples:**
 
 * `!Q`
@@ -41,7 +43,7 @@ Render a text block with an overline by using an exclamation mark `!` for single
 
 === Bold
 
-Render a text block as bold by using an asterix `\*` for single characters or `*(bold)` for multi-character text.
+Render a text block as bold by using an asterik `\*` for single characters or `*(bold)` for multi-character text.
 
 **Examples:**
 

--- a/doc/user-manual/english/circuits/text-style.adoc
+++ b/doc/user-manual/english/circuits/text-style.adoc
@@ -43,7 +43,7 @@ Negations can also be nested, for example `!(ENABLE !(A+B))`.
 
 === Bold
 
-Render a text block as bold by using an asterik `\*` for single characters or `*(bold)` for multi-character text.
+Render a text block as bold by using an asterisk `\*` for single characters or `*(bold)` for multi-character text.
 
 **Examples:**
 

--- a/doc/user-manual/english/styles/styles.adoc
+++ b/doc/user-manual/english/styles/styles.adoc
@@ -38,7 +38,7 @@ The set of styles is predefined by Antares. The following styles are available:
 
 Figure:: This style is the basic style in Antares. It is mainly used for "pure" graphical objects like rectangle, ellipse, line etc.
 
-Element:: This style is used for the vertice elements of the graph that make up the circuit. In Antares these are the circuit components such as logic gates or subcircuits.
+Element:: This style is used for the vertex elements of the graph that make up the circuit. In Antares these are the circuit components such as logic gates or subcircuits.
 
 Connection:: This style is used in Antares for the wires that connect the circuit components.
 

--- a/doc/user-manual/english/subcircuits/subcircuits.adoc
+++ b/doc/user-manual/english/subcircuits/subcircuits.adoc
@@ -29,10 +29,7 @@ Examples:
  !Q
  !(ABC)
 
-Crossbars can also be nested.
-
-Subscript and superscript is possible with the `\_` and `^` marks, e.g. `Mem_(In)` will be displayed as Mem~In~. The `/` mark will make letters _italic_ and `*` will make them bold.
-If this special meaning of the formatting characters is not desired, a backslash can be used to escape them: `I\/O` will become "I/O" instead of "I__O__".
+Negations can also be nested. See link:{{site.basedir}}/user-manual/english/circuits/text-style[Text Style] for more possibilities.
 
 === Bidirectional Ports
 

--- a/doc/user-manual/english/subcircuits/subcircuits.adoc
+++ b/doc/user-manual/english/subcircuits/subcircuits.adoc
@@ -20,12 +20,19 @@ It often happens that you have not yet decided at the beginning of the design of
 
 Ports must have a unique **name** so that they can be identified at various points by the user of the circuit, e.g. in the symbol of the subcircuit. Antares itself uses a different identification of ports internally. If a circuit uses a subcircuit with an input named "A" and a wire leads to this input, Antares does not remember the name "A" as a reference, but the internal number of the port (see below). This allows you to change the names of ports in subcircuits even if the subcircuit is already used in other circuits.
 
+=== Name Styles
+
 Digital circuits often have inputs and outputs that transmit an inverted signal and whose names are marked with a crossbar above the text. An example is a flip-flops with the outputs Q and [overline]#Q#. You can create a crossbar in Antares by placing an exclamation mark in front of the letter that you want to have a crossbar. Longer text with crossbars can be additionally marked with round brackets.
 
 Examples:
 
  !Q
  !(ABC)
+
+Crossbars can also be nested.
+
+Subscript and superscript is possible with the `\_` and `^` marks, e.g. `Mem_(In)` will be displayed as Mem~In~. The `/` mark will make letters _italic_ and `*` will make them bold.
+If this special meaning of the formatting characters is not desired, a backslash can be used to escape them: `I\/O` will become "I/O" instead of "I__O__".
 
 === Bidirectional Ports
 

--- a/draw/shared/src/main/ch/scorpion/jabbah/draw/drawable/RichTextDrawable.kt
+++ b/draw/shared/src/main/ch/scorpion/jabbah/draw/drawable/RichTextDrawable.kt
@@ -15,7 +15,7 @@ import kotlin.math.max
  * Displays a [RichText] AST using [Graphics2D] operations as single-line text.
  */
 class RichTextDrawable(
-	private val richText: RichText,
+	richText: RichText,
 	private val baseFont: Font
 ) : AbstractRectangle() {
 
@@ -221,11 +221,6 @@ class RichTextDrawable(
 
 			return drawable
 		}
-
-		private fun getMaxOverlineLevel(richText: RichText) =
-			richText.children.maxOfOrNull {
-				it.text.styledText.chunks.maxOfOrNull { it.style.overlineLevel } ?: 0
-			} ?: 0
 	}
 
 	/** The coordinates of the [ChunkView]s are relative to the baseline start of the first [ChunkView].*/
@@ -258,7 +253,7 @@ class RichTextDrawable(
 
 	var underline: Boolean = false
 
-	private val maxOverlineLevel = getMaxOverlineLevel(richText)
+	private val maxOverlineLevel = richText.getMaxOverlineLevel()
 
 	override fun draw(context: DrawContext) {
 		val ascent = abs(baselineRect.y)
@@ -360,9 +355,9 @@ class RichTextDrawable(
 
 			g.drawString(text, baselineX.toInt(), baselineY.toInt())
 
-			for (i in 1 .. style.overlineLevel) {
+			for (level in 1 .. style.overlineLevel) {
 				g.stroke = OVERLINE_STROKE
-				val lineY = y - 2 * maxOverlineLevel + 2 * i
+				val lineY = y - 2.5 * ( maxOverlineLevel - level)
 				if (style.italic) {
 					g.drawLine(x + 2, lineY, x + width, lineY)
 				} else {

--- a/draw/shared/src/main/ch/scorpion/jabbah/draw/drawable/RichTextDrawable.kt
+++ b/draw/shared/src/main/ch/scorpion/jabbah/draw/drawable/RichTextDrawable.kt
@@ -15,6 +15,7 @@ import kotlin.math.max
  * Displays a [RichText] AST using [Graphics2D] operations as single-line text.
  */
 class RichTextDrawable(
+	private val richText: RichText,
 	private val baseFont: Font
 ) : AbstractRectangle() {
 
@@ -98,7 +99,7 @@ class RichTextDrawable(
 		 * with [Graphics2D] operations. Currently supports only single-line text.
 		 */
 		private fun transformToSingleLine(richText: RichText, font: Font, textMeasurer: TextMeasurer): RichTextDrawable {
-			val drawable = RichTextDrawable(font)
+			val drawable = RichTextDrawable(richText, font)
 			var baselineX = 0.0
 
 			richText.children.forEach { fragment ->
@@ -133,7 +134,7 @@ class RichTextDrawable(
 		}
 
 		private fun transformToMultiline(richText: RichText, font: Font, preferredWidth: Double, textMeasurer: TextMeasurer): RichTextDrawable {
-			val drawable = RichTextDrawable(font)
+			val drawable = RichTextDrawable(richText, font)
 			var baselineX = 0.0
 			var baselineY = 0.0
 			var lineWidth = 0.0
@@ -220,6 +221,11 @@ class RichTextDrawable(
 
 			return drawable
 		}
+
+		private fun getMaxOverlineLevel(richText: RichText) =
+			richText.children.maxOfOrNull {
+				it.text.styledText.chunks.maxOfOrNull { it.style.overlineLevel } ?: 0
+			} ?: 0
 	}
 
 	/** The coordinates of the [ChunkView]s are relative to the baseline start of the first [ChunkView].*/
@@ -252,10 +258,12 @@ class RichTextDrawable(
 
 	var underline: Boolean = false
 
+	private val maxOverlineLevel = getMaxOverlineLevel(richText)
+
 	override fun draw(context: DrawContext) {
 		val ascent = abs(baselineRect.y)
 		context.g.translate(location.x, location.y + ascent)
-		chunkViews.forEach { it.draw(context.g) }
+		chunkViews.forEach { it.draw(context.g, maxOverlineLevel) }
 		context.g.translate(-location.x, -location.y - ascent)
 	}
 
@@ -263,7 +271,7 @@ class RichTextDrawable(
 		val ascent = abs(baselineRect.y)
 		g.translate(location.x, location.y + ascent)
 
-		chunkViews.forEach { it.draw(g) }
+		chunkViews.forEach { it.draw(g, maxOverlineLevel) }
 		if (underline) {
 			val y = -ascent.toInt() + heightInt + 1
 			g.stroke = UNDERLINE_STROKE
@@ -346,18 +354,19 @@ class RichTextDrawable(
 			height = tri.textBounds.height
 		}
 
-		fun draw(g: Graphics2D) {
+		fun draw(g: Graphics2D, maxOverlineLevel: Int) {
 
 			g.font = localFont
 
 			g.drawString(text, baselineX.toInt(), baselineY.toInt())
 
-			if (style.overline) {
+			for (i in 1 .. style.overlineLevel) {
 				g.stroke = OVERLINE_STROKE
+				val lineY = y - 2 * maxOverlineLevel + 2 * i
 				if (style.italic) {
-					g.drawLine(x + 2, y, x + width, y)
+					g.drawLine(x + 2, lineY, x + width, lineY)
 				} else {
-					g.drawLine(x, y, x + width, y)
+					g.drawLine(x, lineY, x + width, lineY)
 				}
 			}
 
@@ -371,4 +380,3 @@ class RichTextDrawable(
 		}
 	}
 }
-


### PR DESCRIPTION
This PR adds the ability to nest overbars, as is often needed in NAND worlds.
Since this is my first contact with Kotlin, please tell me if anything is not idiomatic.

![grafik](https://github.com/flandreas/antares-source/assets/5798899/b0075ccd-5db4-4e88-b978-d9bff04645c3)

Proper care is taken to take multiple nesting possibilities into account, e.g. abominations like this:
![grafik](https://github.com/flandreas/antares-source/assets/5798899/1478be3e-aaa6-4696-b9ef-16cde826ded3)
