### PR TITLE
Sort tunnel names in tunnel properties

### DIFF
--- a/antares/jvm/src/main/ch/scorpion/antares/view/net/TunnelNameProperty.kt
+++ b/antares/jvm/src/main/ch/scorpion/antares/view/net/TunnelNameProperty.kt
@@ -4,6 +4,7 @@ import ch.scorpion.antares.model.DigitalGraph
 import ch.scorpion.antares.model.net.TunnelName
 import ch.scorpion.jabbah.base.StringUtils
 import ch.scorpion.jabbah.base.Translations
+import ch.scorpion.jabbah.base.richtext.RichText
 import ch.scorpion.jabbah.edit.AbstractPropertyCommand
 import ch.scorpion.jabbah.edit.Bean
 import ch.scorpion.jabbah.edit.BeanProvider
@@ -104,7 +105,11 @@ class TunnelNameEditor(
 	private val comboBox: JComboBox<TunnelName> get() = comboBoxEditor.customEditor as JComboBox<TunnelName>
 
 	init {
-		comboBox.model = DefaultComboBoxModel(graph.tunnelNames.toTypedArray())
+		comboBox.model = DefaultComboBoxModel(
+			graph.tunnelNames
+				.sortedBy { RichText.stripToPlainText(it.name) }
+				.toTypedArray()
+		)
 		comboBox.isEditable = true
 		editor = comboBox
 	}


### PR DESCRIPTION
I think it's a good idea to sort the tunnels by their plain name in the combo box. Previously, this appeared to be random to the user (probably creation order / id).
![grafik](https://github.com/flandreas/antares-source/assets/5798899/63784dce-f928-42af-ab3c-8c827f0e1c83)
