### PR TITLE
Use plain text for keyboard view

### DIFF
--- a/antares/shared/src/main/ch/scorpion/antares/view/input/KeyboardView.kt
+++ b/antares/shared/src/main/ch/scorpion/antares/view/input/KeyboardView.kt
@@ -66,7 +66,8 @@ class KeyboardView(
 		color = styleProvider.getStyle(StyleType.BACKGROUND).color.textColor,
 		horizontalAlignment = HorizontalAlignment.LEFT,
 		verticalAlignment = VerticalAlignment.CENTER,
-		location = Point2D(AbstractAntaresPortView.LENGTH + INSET + TEXT_INSET, 0))
+		location = Point2D(AbstractAntaresPortView.LENGTH + INSET + TEXT_INSET, 0),
+		richText = false)
 
 	private val propertiesBackgroundColor get() = if (Look.FILL_BASIC_COMPONENTS) backgroundColor else styleProvider.getStyle(StyleType.BACKGROUND).color.backgroundColor
 

--- a/base/shared/src/main/ch/scorpion/jabbah/base/richtext/RichTextSyntaxTree.kt
+++ b/base/shared/src/main/ch/scorpion/jabbah/base/richtext/RichTextSyntaxTree.kt
@@ -5,6 +5,7 @@ import ch.scorpion.jabbah.base.dsl.AbstractNode
 import ch.scorpion.jabbah.base.dsl.Compound
 import ch.scorpion.jabbah.base.parser.TextLocation
 import ch.scorpion.jabbah.base.richtext.TextStyle.Companion.NORMAL
+import ch.scorpion.jabbah.base.parser.TextLocation.Companion.UNDEFINED
 import kotlin.math.max
 
 class RichText(
@@ -35,6 +36,26 @@ class RichText(
 				text.replace("/", " ")
 			}
 		}
+
+		/**
+		 * Treats the text as plain text and creates a [RichText] object that ignores all markup.
+		 */
+		fun asPlain(text: String) =
+			RichText(
+				UNDEFINED,
+				listOf(
+					Fragment(
+						UNDEFINED,
+						FragmentText(
+							UNDEFINED,
+							StyledText(
+								UNDEFINED,
+								listOf(StyledChunk(UNDEFINED, text))
+							)
+						)
+					)
+				)
+			)
 	}
 
 	fun getMaxOverlineLevel() =

--- a/draw/shared/src/main/ch/scorpion/jabbah/draw/drawable/RichTextDrawable.kt
+++ b/draw/shared/src/main/ch/scorpion/jabbah/draw/drawable/RichTextDrawable.kt
@@ -60,6 +60,12 @@ class RichTextDrawable(
 				}
 			}
 
+		/**
+		 * Treats the text as-is and creates a [RichTextDrawable] that ignores all markup.
+		 */
+		fun asPlain(text: String, font: Font, textMeasurer: TextMeasurer = TextRenderInfoFactory) =
+			transformToSingleLine(RichText.asPlain(text), font, textMeasurer)
+
 		fun multiline(text: String, font: Font, preferredWidth: Double, textMeasurer: TextMeasurer = TextRenderInfoFactory): RichTextDrawable =
 			try {
 				transformToMultiline(RichTextParser(text).parse(), font, preferredWidth, textMeasurer)
@@ -77,21 +83,7 @@ class RichTextDrawable(
 		 */
 		private fun legacyRichText(text: String, error: SyntaxError): RichText {
 			LOG.debug("Resorting to legacy format: ${error.message} at ${error.location}")
-			return RichText(
-				UNDEFINED,
-				listOf(
-					Fragment(
-						UNDEFINED,
-						FragmentText(
-							UNDEFINED,
-							StyledText(
-								UNDEFINED,
-								listOf(StyledChunk(UNDEFINED, text))
-							)
-						)
-					)
-				)
-			)
+			return RichText.asPlain(text)
 		}
 
 		/**

--- a/edit/shared/src/main/ch/scorpion/jabbah/edit/model/text/Label.kt
+++ b/edit/shared/src/main/ch/scorpion/jabbah/edit/model/text/Label.kt
@@ -39,7 +39,8 @@ class Label(
 	rotationDisplayStrategy: RotationDisplayStrategy = RotationDisplayStrategy.IGNORE,
 	val rotation: Rotation = Rotation.R0,
 	ownerRotation: Rotation = Rotation.R0,
-	displayableText: RichTextDrawable = RichTextDrawable.of(text ?: "", font)
+	displayableText: RichTextDrawable = RichTextDrawable.of(text ?: "", font),
+	val richText: Boolean = true
 ) : AbstractDrawable(), Mirrorable, Locatable {
 
 	companion object {
@@ -53,7 +54,11 @@ class Label(
 			if (field != value) {
 				invalidate()
 				field = value
-				displayableText = RichTextDrawable.of(value, font)
+				if (richText) {
+					displayableText = RichTextDrawable.of(value, font)
+				} else {
+					displayableText = RichTextDrawable.asPlain(value, font)
+				}
 				updateGeometry()
 			}
 		}

--- a/edit/shared/src/main/ch/scorpion/jabbah/edit/model/text/Label.kt
+++ b/edit/shared/src/main/ch/scorpion/jabbah/edit/model/text/Label.kt
@@ -39,8 +39,8 @@ class Label(
 	rotationDisplayStrategy: RotationDisplayStrategy = RotationDisplayStrategy.IGNORE,
 	val rotation: Rotation = Rotation.R0,
 	ownerRotation: Rotation = Rotation.R0,
-	displayableText: RichTextDrawable = RichTextDrawable.of(text ?: "", font),
-	val richText: Boolean = true
+	val richText: Boolean = true,
+	displayableText: RichTextDrawable = if (richText) RichTextDrawable.of(text ?: "", font) else RichTextDrawable.asPlain(text ?: "", font)
 ) : AbstractDrawable(), Mirrorable, Locatable {
 
 	companion object {

--- a/edit/shared/src/test/ch/scorpion/jabbah/edit/model/text/LabelTest.kt
+++ b/edit/shared/src/test/ch/scorpion/jabbah/edit/model/text/LabelTest.kt
@@ -23,4 +23,15 @@ class LabelTest {
         val label = Label(text = "Test", font = FontImpl(LogicalFontFamily.SANS_SERIF, FontStyle.PLAIN.value, 10))
         assertEquals("Test", label.text)
     }
+
+    @Test
+    fun shouldConstructWithPlainText() {
+        val label = Label(
+            text = "!x",
+            font = FontImpl(LogicalFontFamily.MONOSPACED, FontStyle.PLAIN.value, 10),
+            richText = false)
+        assertEquals("!x", label.text)
+        label.text = "!"
+        assertEquals("!", label.text)
+    }
 }

--- a/edit/shared/src/test/ch/scorpion/jabbah/edit/model/text/LabelTest.kt
+++ b/edit/shared/src/test/ch/scorpion/jabbah/edit/model/text/LabelTest.kt
@@ -26,12 +26,11 @@ class LabelTest {
 
     @Test
     fun shouldConstructWithPlainText() {
+        // essentially, check that the constructor doesn't throw - which it would if it parsed the text as RichText
         val label = Label(
-            text = "!x",
+            text = "!",
             font = FontImpl(LogicalFontFamily.MONOSPACED, FontStyle.PLAIN.value, 10),
             richText = false)
-        assertEquals("!x", label.text)
-        label.text = "!"
         assertEquals("!", label.text)
     }
 }


### PR DESCRIPTION
This addresses flandreas/antares#725:

* since RichText seems to be used for everything, I didn't find a `Drawable` that simply displays text
* instead, I added a `richText` boolean property to `Label`, allowing to use a label where rich text is not desired
* if rich text is not desired, the new `RichText.asPlain` method is used to construct a `RichText` object from an unparsed text

One thing I couldn't solve: If the `richText` property is set to false, the initial text is still parsed because `text` is initialized first and uses the default value of `richText` which is true. I don't know how to fix this without changing the initialization order.

Finally, this doesn't solve the other issue mentioned in the ticket where space and enter on the keyboard also trigger the respective hotkey actions, e.g. pausing the simulation.