### PR TITLE
#730: Edge-triggered RAM writes

### DIFF
--- a/antares/shared/src/main/ch/scorpion/antares/model/addressable/RAM.kt
+++ b/antares/shared/src/main/ch/scorpion/antares/model/addressable/RAM.kt
@@ -67,6 +67,11 @@ class RAM(
 				} else {
 					removePort(getPort<DigitalSignal>(CLOCK_PORT_NAME))
 				}
+				val writePort = getPort<DigitalSignal>(WRITE_PORT_NAME)
+				if (writePort is DigitalPortImpl) {
+					// writing is level-triggered if and only if we a clock input
+					writePort.trigger = if (value) Trigger.LEVEL else Trigger.EDGE
+				}
 			}
 		}
 

--- a/antares/shared/src/main/ch/scorpion/antares/model/addressable/RAMCalculator.kt
+++ b/antares/shared/src/main/ch/scorpion/antares/model/addressable/RAMCalculator.kt
@@ -83,6 +83,7 @@ class RAMCalculator : VerticeCalculator<RAM> {
         if (data.changedPort === ram.getClearInput()) {
             ram.clear()
             read(ram, signalHandler)
+            return
         }
 
         if (ram.isChipSelected) {
@@ -97,30 +98,18 @@ class RAMCalculator : VerticeCalculator<RAM> {
 	    }
 	    ram.currentSelectedAddress = addressInt
 
-	    if (data.changedPort === ram.getAddressInput()) {
-		    readOrWrite(ram, signalHandler)
-	    } else if (data.changedPort === ram.getDataPort()) {
-		    readOrWrite(ram, signalHandler)
-	    } else if (data.changedPort === ram.getChipSelectInput()) {
-		    readOrWrite(ram, signalHandler)
-	    } else if (data.changedPort === ram.getWriteInput()) {
-		    if (ram.isRead) {
-			    readOrWrite(ram, signalHandler)
-		    } else {
-			    undefinedOutput(ram, signalHandler)
-		    }
-	    } else if (data.changedPort === null) {
-	    	if (ram.isRead) {
-	    		read(ram, signalHandler)
-		    }
-	    }
-    }
-
-    private fun readOrWrite(ram: RAM, signalHandler: SignalHandler) {
-        if (ram.isWrite) {
+        if (data.changedPort === ram.getWriteInput() && ram.isWrite) {
+            // edge-triggered write
             write(ram, signalHandler)
+            undefinedOutput(ram, signalHandler)
         } else {
-            read(ram, signalHandler)
+            // otherwise: level-triggered read
+            if (ram.isWrite) {
+                // pending write
+			    undefinedOutput(ram, signalHandler)
+            } else {
+                read(ram, signalHandler)
+            }
         }
     }
 

--- a/antares/shared/src/test/ch/scorpion/antares/model/addressable/RAMCalculatorTest.kt
+++ b/antares/shared/src/test/ch/scorpion/antares/model/addressable/RAMCalculatorTest.kt
@@ -103,9 +103,29 @@ class RAMCalculatorTest {
 		ram.getAddressInput().setIncomingSignal(DigitalSignalFactory.of(BitWidth.BW_8, 1L), signalHandler)
 		ram.getDataPort().setIncomingSignal(DigitalSignalFactory.of(BitWidth.BW_8, 99L), signalHandler)
 
-		calculator.calculate(ram, ram.createActorData(ram.getDataPort()), signalHandler)
+		calculator.calculate(ram, ram.createActorData(ram.getWriteInput()), signalHandler)
 
 		assertEquals(99UL, ram.read(1))
+	}
+
+	@Test
+	fun shouldWriteUnclockedEdgeTriggeredOnly() {
+		val ram = createRam(false)
+		ram.getChipSelectInput().setIncomingSignal(DigitalSignalFactory.of(true), signalHandler)
+		ram.getClearInput().setIncomingSignal(DigitalSignalFactory.of(false), signalHandler)
+		
+		// write 0 <- 1
+		ram.getAddressInput().setIncomingSignal(DigitalSignalFactory.of(BitWidth.BW_8, 0L), signalHandler)
+		ram.getDataPort().setIncomingSignal(DigitalSignalFactory.of(BitWidth.BW_8, 99L), signalHandler)
+		ram.getWriteInput().setIncomingSignal(DigitalSignalFactory.of(true), signalHandler)
+		calculator.calculate(ram, ram.createActorData(ram.getWriteInput()), signalHandler)
+
+		// with the write pulse still present, change address to 1
+		ram.getAddressInput().setIncomingSignal(DigitalSignalFactory.of(BitWidth.BW_8, 1L), signalHandler)
+		calculator.calculate(ram, ram.createActorData(ram.getAddressInput()), signalHandler)
+
+		// the address change should have no effect as writing should be edge-triggered
+		assertEquals(0UL, ram.read(1))
 	}
 
 	@Test

--- a/doc/user-manual/english/base-library/ram.adoc
+++ b/doc/user-manual/english/base-library/ram.adoc
@@ -16,7 +16,7 @@ The RAM component provides two different interfaces that can be selected via the
 
 Synchronous:: With this interface the RAM contains the clock input "CLK". If the input "WR" has the value 1, the data present at input "D" is read on the rising edge of the clock input.
 
-Asynchronous:: With this interface the RAM does not contain a clock input. If input "WR" has the value 1, the data present at input "D" are read each time they change.
+Asynchronous:: With this interface the RAM does not contain a clock input. Instead, "WR" is edge-triggered in this case. That is, if the input "WR" reaches the value 1, the data present at input "D" is read once. For a new write, "WR" has to go back to the value 0 first.
 
 == Pins
 
@@ -28,7 +28,7 @@ D:: Input/Output "Data": Outputs the data to be read or accepts the data to be w
 
 CLK:: Input "Clock": Is only displayed if the property "Clock Input" is set. At the rising edge of the CLK signal, data is read or written, depending on the value of "WR".
 
-WR:: Input "Write": With the value 1 data can be written into the RAM.
+WR:: Input "Write": With the value 1 data can be written into the RAM once per clock cycle or write edge.
 
 CLR:: Input "Clear": Asynchronous input at which a value of 1 causes all memory cells to be reset to the value 0, independent of the other inputs.
 


### PR DESCRIPTION
This PR addresses flandreas/antares#730. I believe the previous behavior would be impossible to implement in real hardware, so this makes it more realistic - and matches the distributed RAM in all FPGAs I've encountered. Example from Xilinx ([source](https://webpages.uidaho.edu/~jfrenzel/440/Handouts/Memory/Distributed%20Memory/Distributed%20Memory%20Example.pdf)):

![grafik](https://github.com/flandreas/antares-source/assets/5798899/1d503481-d7af-4849-b067-9c3bbc6f943b)

Here, an additional WCLK is introduced to make WRITE_EN edge-triggered. But that's only an implementation detail because FPGAs should never use non-clock signals for edge triggering, but the principle stays the same: Writing must be edge-driven.

But still, this is a suggested change in behavior rather than a bugfix.