### PR TITLE
#733: Keyboard improvements

### DIFF
--- a/antares/jvm/rsc/antares_de.properties
+++ b/antares/jvm/rsc/antares_de.properties
@@ -317,6 +317,8 @@ element.property.logic.desc = Bestimmt das Logik-Verhalten eines Kontrolleingang
   <strong>Negativ</strong>: Der Kontrolleingang ist mit dem Signal 0 aktiv.<br>
 element.property.logic.positive = Positiv
 element.property.logic.negative = Negativ
+element.property.enterBehavior.cr = CR (\\r)
+element.property.enterBehavior.lf = LF (\\n)
 element.property.trigger.name = Steuerung
 element.property.trigger.desc = Mit "Taktflanke" wird im Symbol ein kleines Dreieck für diesen Anschluss angezeigt.
 element.property.trigger.level = Taktzustand
@@ -386,6 +388,8 @@ element.property.LEDMatrix.isCircleDots.desc = Antares zeichnet die Leuchpunkte 
   Wenn diese Eigenschaft gesetzt ist, werden die Leuchtpunkte als Kreis gezeichnet.
 element.property.AndGate.dataPort.name = Daten-Eingang
 element.property.AndGate.dataPort.desc = Spezifiziert die Nummer des Eingangs, der die Nutz-Daten empfängt, wenn das Feature "Daten-Fluss" des UND-Gatters verwendet wird. Bezüglich der Richtung, in der die Daten durch das UND-Gatter fliessen, bezeichnet die Nummer 1 den Eingang auf der linken Seite.
+element.property.Keyboard.enterBehavior.name = Verhalten der Enter-Taste
+element.property.Keyboard.enterBehavior.desc = Welcher Code beim Drücken von Enter gesendet wird.
 element.property.outputAnnotation.name = Annotation Ausgang
 element.property.outputAnnotation.desc = Abhängig vom Wert wird für diesen Anschluss innerhalb des Symbols die entsprechende Annotation angezeigt.
 element.property.OutputAnnotation.none = Keine

--- a/antares/jvm/rsc/antares_en.properties
+++ b/antares/jvm/rsc/antares_en.properties
@@ -324,6 +324,8 @@ element.property.logic.desc = Determines the logic of control inputs.<br> \
   <strong>Negative</strong>: The control input is active at value 0.<br>
 element.property.logic.positive = Positive
 element.property.logic.negative = Negative
+element.property.enterBehavior.cr = CR (\\r)
+element.property.enterBehavior.lf = LF (\\n)
 element.property.trigger.name = Triggering
 element.property.trigger.desc = With the value "Edge" a small triangle is displayed inside the symbol for the pin.
 element.property.trigger.level = Level
@@ -393,6 +395,8 @@ element.property.LEDMatrix.isCircleDots.desc = Normally Antares draws the light 
   If this attribute is set, small circles are drawn instead.
 element.property.AndGate.dataPort.name = Data Input
 element.property.AndGate.dataPort.desc = In this attribute the number of the input containing the data path can be selected if the feature "Data Path" is to be used. In the direction of data flow through the AND gate, number 1 designates the left-most input.
+element.property.Keyboard.enterBehavior.name = Enter behavior
+element.property.Keyboard.enterBehavior.desc = Which code to emit when the enter key is pressed.
 element.property.OutputAnnotation.none = None
 element.property.outputAnnotation.name = Output Annotation
 element.property.outputAnnotation.desc = Depending on the value "None", "Tri-State" or "Master-Slave", the corresponding annotation is displayed within the symbol for the pin.

--- a/antares/jvm/src/main/ch/scorpion/antares/AntaresModuleJvm.kt
+++ b/antares/jvm/src/main/ch/scorpion/antares/AntaresModuleJvm.kt
@@ -233,6 +233,7 @@ class AntaresModuleJvm(private val app: AntaresDesktop) : AbstractModule() {
 		registry.registerRenderer(TunnelFlowDirection::class.java, EnumRenderer::class.java)
 		registry.registerRenderer(NetSignalApplierStrategy::class.java, EnumRenderer::class.java)
 		registry.registerRenderer(TunnelName::class.java, DefaultTableCellRenderer::class.java)
+		registry.registerRenderer(EnterBehavior::class.java, EnumRenderer::class.java)
 	}
 
 	private fun configurePropertyEditors(registry: DynamicPropertyEditorRegistry) {
@@ -257,6 +258,7 @@ class AntaresModuleJvm(private val app: AntaresDesktop) : AbstractModule() {
 		registry.registerEditor(TunnelFlowDirection::class.java, TunnelFlowDirectionEditor::class.java)
 		registry.registerEditor(NetSignalApplierStrategy::class.java, NetSignalApplierChoiceEditor::class.java)
 		registry.register(TunnelName::class.java) { TunnelNameEditor((it as TunnelNameProperty).graph) }
+		registry.registerEditor(EnterBehavior::class.java, EnterBehaviorEditor::class.java)
 
 		registry.register(BitWidth::class.java) { prop ->
 			BitWidthEditor(

--- a/antares/jvm/src/main/ch/scorpion/antares/view/AntaresPropertyUIs.kt
+++ b/antares/jvm/src/main/ch/scorpion/antares/view/AntaresPropertyUIs.kt
@@ -13,6 +13,7 @@ import ch.scorpion.antares.view.net.TunnelFlowDirection
 import ch.scorpion.antares.view.output.LightColor
 import ch.scorpion.antares.view.output.VideoRamColorModel
 import ch.scorpion.antares.view.port.DigitalPortViewStyle
+import ch.scorpion.antares.view.EnterBehaviorEditor
 import ch.scorpion.jabbah.base.Translations
 import ch.scorpion.jabbah.base.sound.WaveformType
 import ch.scorpion.jabbah.base.swing.ColorIcon
@@ -86,6 +87,13 @@ class LogicEditor : ComboBoxPropertyEditor() {
     init {
         setAvailableValues(Logic.values())
         (editor as JComboBox<*>).renderer = EnumRenderer<Logic>()
+    }
+}
+
+class EnterBehaviorEditor : ComboBoxPropertyEditor() {
+    init {
+        setAvailableValues(EnterBehavior.values())
+        (editor as JComboBox<*>).renderer = EnumRenderer<EnterBehavior>()
     }
 }
 
@@ -186,4 +194,3 @@ class NetSignalApplierChoiceEditor : ComboBoxPropertyEditor() {
 		(editor as JComboBox<*>).renderer = EnumRenderer<NetSignalApplierStrategy>()
 	}
 }
-

--- a/antares/jvm/src/main/ch/scorpion/antares/view/input/KeyboardViewBeanInfo.kt
+++ b/antares/jvm/src/main/ch/scorpion/antares/view/input/KeyboardViewBeanInfo.kt
@@ -1,5 +1,6 @@
 package ch.scorpion.antares.view.input
 
+import ch.scorpion.antares.model.EnterBehavior
 import ch.scorpion.jabbah.edit.Editor
 import ch.scorpion.jabbah.edit.componentBeanProvider
 import ch.scorpion.jabbah.edit.properties.CommandPropertySwing
@@ -11,10 +12,12 @@ class KeyboardViewBeanInfo : VerticeViewBeanInfo<KeyboardView>() {
 
 	companion object {
 		private val bufferSize = CommandPropertySwing("bufferSize", "element.property.bufferSize", Int::class.java, componentBeanProvider)
-	}
+		private val enterBehavior = CommandPropertySwing("enterBehavior", "element.property.Keyboard.enterBehavior", EnterBehavior::class.java, componentBeanProvider)
+ 	}
 
 	override fun addProperties(bean: KeyboardView, editor: Editor, properties: MutableList<Property>) {
 		super.addProperties(bean, editor, properties)
 		properties.add(bufferSize.bind(editor, beanIdProvider(bean.id)))
+		properties.add(enterBehavior.bind(editor, beanIdProvider(bean.id)))
 	}
 }

--- a/antares/shared/src/main/ch/scorpion/antares/model/EnterBehavior.kt
+++ b/antares/shared/src/main/ch/scorpion/antares/model/EnterBehavior.kt
@@ -1,0 +1,36 @@
+package ch.scorpion.antares.model
+
+import ch.scorpion.jabbah.base.Translations
+import ch.scorpion.jabbah.base.EnumProperty
+
+/**
+ * Represents the type of enter key behavior of [Keyboard]s.
+ */
+enum class EnterBehavior(override val customName: String) : EnumProperty<EnterBehavior> {
+
+	/** Sends \r. */
+	CR("cr"),
+
+	/** Sends \n .*/
+	LF("lf");
+
+    companion object {
+	    const val BASE_KEY = "element.property.enterBehavior"
+
+        fun withName(customName: String): EnterBehavior {
+            for (code in values()) {
+                if (code.customName == customName) {
+                    return code
+                }
+            }
+            throw IllegalArgumentException("unknown EnterBehavior $customName")
+        }
+    }
+
+    override fun toString(): String {
+        return when (this) {
+            CR -> Translations.getString("element.property.enterBehavior.cr")
+            LF -> Translations.getString("element.property.enterBehavior.lf")
+        }
+    }
+}

--- a/antares/shared/src/main/ch/scorpion/antares/model/input/Keyboard.kt
+++ b/antares/shared/src/main/ch/scorpion/antares/model/input/Keyboard.kt
@@ -2,6 +2,7 @@ package ch.scorpion.antares.model.input
 
 import ch.scorpion.antares.model.Trigger
 import ch.scorpion.antares.model.port.DigitalPort
+import ch.scorpion.antares.model.EnterBehavior
 import ch.scorpion.antares.model.port.DigitalPortImpl
 import ch.scorpion.antares.model.signal.Bit
 import ch.scorpion.antares.model.signal.BitWidth
@@ -31,7 +32,8 @@ import ch.scorpion.jabbah.io.StoreWriter
  * [InputPort] is set, the oldest key entry is removed from the buffer and forwarded to the [OutputPort].
  */
 class Keyboard(
-	bufferSize: Int = DEFAULT_BUFFER_SIZE
+	bufferSize: Int = DEFAULT_BUFFER_SIZE,
+	var enterBehavior: EnterBehavior = EnterBehavior.LF
 ) : CalculatingVertice(KeyboardCalculator()) {
 
 	companion object {
@@ -114,11 +116,15 @@ class Keyboard(
 	override fun write(writer: StoreWriter) {
 		super.write(writer)
 		writer.writeInt("bufferSize", bufferSize)
+		writer.writeString("enterBehavior", enterBehavior.customName)
 	}
 
 	override fun read(reader: StoreReader) {
 		super.read(reader)
 		bufferSize = reader.readInt("bufferSize")
+	    if (reader.hasAttribute("enterBehavior")) {
+			enterBehavior = EnterBehavior.withName(reader.readString("enterBehavior"))
+	    }
 	}
 
 	/** ---- [Keyboard] */
@@ -133,7 +139,7 @@ class Keyboard(
 
 	fun enter(byte: Byte, signalHandler: SignalHandler) {
 		if (bufferItemsCount < bufferSize) {
-			buffer.add(byte)
+			buffer.add(byte)				
 			stateChanged(signalHandler)
 			requestActingAfter(signalHandler, propagationDelay, createActorData(null))
 		}
@@ -171,4 +177,3 @@ class Keyboard(
 		}
 	}
 }
-

--- a/antares/shared/src/main/ch/scorpion/antares/view/input/KeyboardView.kt
+++ b/antares/shared/src/main/ch/scorpion/antares/view/input/KeyboardView.kt
@@ -1,6 +1,7 @@
 package ch.scorpion.antares.view.input
 
 import ch.scorpion.antares.model.input.Keyboard
+import ch.scorpion.antares.model.EnterBehavior
 import ch.scorpion.antares.view.Look
 import ch.scorpion.antares.view.port.AbstractAntaresPortView
 import ch.scorpion.antares.view.port.DigitalPortView
@@ -9,6 +10,7 @@ import ch.scorpion.jabbah.base.geom.Direction
 import ch.scorpion.jabbah.base.geom.Point2D
 import ch.scorpion.jabbah.base.logger
 import ch.scorpion.jabbah.base.module.BaseModule
+import ch.scorpion.jabbah.base.event.KeyEvent
 import ch.scorpion.jabbah.draw.DrawContext
 import ch.scorpion.jabbah.draw.graphics.DropShadow
 import ch.scorpion.jabbah.draw.graphics.LogicalFontFamily
@@ -86,6 +88,16 @@ class KeyboardView(
 			if (value != model.bufferSize) {
 				invalidate()
 				model.bufferSize = value
+				invalidate()
+			}
+		}
+
+	var enterBehavior: EnterBehavior
+		get() = model.enterBehavior
+		set(value) {
+			if (value != model.enterBehavior) {
+				invalidate()
+				model.enterBehavior = value
 				invalidate()
 			}
 		}
@@ -268,8 +280,13 @@ class KeyboardView(
 		override fun keyPressed(context: ActorInteractionContext): ActorInteractionHandler? {
 			val keyChar = context.keyEvent!!.keyChar
 			LOG.trace("keyPressed '$keyChar'")
-			if (KeyHandler.acceptKey(keyChar)) {
-				model.enter(keyChar.code.toByte(), context.signalHandler)
+			if (KeyHandler.acceptKey(keyChar.code)) {
+				var code = when (keyChar.code) {
+					KeyEvent.VK_ESCAPE -> KeyHandler.ESCAPE
+					'\n'.code -> if (model.enterBehavior == EnterBehavior.CR) '\r'.code.toByte() else '\n'.code.toByte()
+					else -> keyChar.code
+				}
+				model.enter(code.toByte(), context.signalHandler)
 			} else {
 				LOG.trace("reject character '$keyChar'")
 			}
@@ -278,26 +295,48 @@ class KeyboardView(
 	}
 
 	object KeyHandler {
-
-		private const val BACKSPACE = 8
-		private const val TAB = 9
-		private const val LINEFEED = 10
+		const val ESCAPE = 27
 		private const val MIN_CHAR = ' '.code
 		private const val MAX_CHAR = '~'.code
+		private const val MAX_ASCII = 127
 
-		fun acceptKey(keyChar: Char): Boolean {
-			return keyChar.code in MIN_CHAR..MAX_CHAR
-				|| keyChar.code == BACKSPACE
-				|| keyChar.code == TAB
-				|| keyChar.code == LINEFEED
-		}
+		fun acceptKey(keyCode: Int) = keyCode <= MAX_ASCII
 
 		fun displayKey(keyChar: Int): String {
 			return when (keyChar) {
 				in MIN_CHAR..MAX_CHAR -> keyChar.toChar().toString()
-				BACKSPACE -> "\\b"
-				TAB -> "\\t"
-				LINEFEED -> "\\n"
+				0 -> "<NUL>"	// CTRL + @
+				1 -> "<SOH>"	// CTRL + A
+				2 -> "<STX>"	// CTRL + B
+				3 -> "<ETX>"	// CTRL + C
+				4 -> "<EOT>"	// CTRL + D
+				5 -> "<ENQ>"	// CTRL + E
+				6 -> "<ACK>"	// CTRL + F
+				7 -> "<BEL>"	// CTRL + G
+				8 -> "\\b"		// CTRL + H
+				9 -> "\\t"		// CTRL + I
+				10 -> "\\n"		// CTRL + J
+				11 -> "<VT>"	// CTRL + K
+				12 -> "<FF>"	// CTRL + L
+				13 -> "\\r"		// CTRL + M
+				14 -> "<SO>"	// CTRL + N
+				15 -> "<SI>"	// CTRL + O
+				16 -> "<DLE>"	// CTRL + P
+				17 -> "<DC1>"	// CTRL + Q
+				18 -> "<DC2>"	// CTRL + R
+				19 -> "<DC3>"	// CTRL + S
+				20 -> "<DC4>"	// CTRL + T
+				21 -> "<NAK>"	// CTRL + U
+				22 -> "<SYN>"	// CTRL + V
+				23 -> "<ETB>"	// CTRL + W
+				24 -> "<CAN>"	// CTRL + X
+				25 -> "<EM>"	// CTRL + Y
+				26 -> "<SUB>"	// CTRL + Z
+				27 -> "<ESC>"	// CTRL + [
+				28 -> "<FS>"	// CTRL + \
+				29 -> "<GS>"	// CTRL + ]
+				30 -> "<RS>"	// CTRL + ^
+				31 -> "<US>"	// CTRL + _
 				else -> ""
 			}
 		}


### PR DESCRIPTION
This implements the suggestions of flandreas/antares#733.

Interestingly, pressing ctrl and a key already produces the correct codes. If this isn't the case on all platforms: The procedure is to take the ASCII code of the key and bit-and it with 0b0011111 to get the control code.