### PR TITLE
Add minOnTime to ImageSwitch

### DIFF
--- a/antares/jvm/src/main/ch/scorpion/antares/view/input/ImageSwitchViewBeanInfo.kt
+++ b/antares/jvm/src/main/ch/scorpion/antares/view/input/ImageSwitchViewBeanInfo.kt
@@ -13,6 +13,7 @@ class ImageSwitchViewBeanInfo : DigitalComponentViewBeanInfo<ImageSwitchView>() 
 
     companion object {
         private val toggle = CommandPropertySwing("toggle", SwitchView.BASE_KEY_TOGGLE, Boolean::class.java, componentBeanProvider)
+        private val minOnTime = CommandPropertySwing("minOnTime", SwitchView.MIN_ON_TIME, Long::class.java, componentBeanProvider)
         private val portDirection = CommandPropertySwing("portDirection", "library.element.ImageSwitch.portDirection", Direction::class.java, componentBeanProvider)
         private val onImage = CommandPropertySwing("onImageId", "library.element.ImageSwitch.onImage", ImageIdentification::class.java, componentBeanProvider)
         private val offImage = CommandPropertySwing("offImageId", "library.element.ImageSwitch.offImage", ImageIdentification::class.java, componentBeanProvider)
@@ -26,5 +27,9 @@ class ImageSwitchViewBeanInfo : DigitalComponentViewBeanInfo<ImageSwitchView>() 
         properties.add(onImage.bind(editor, beanIdProvider(bean.id)))
         properties.add(offImage.bind(editor, beanIdProvider(bean.id)))
         properties.add(scale.bind(editor, beanIdProvider(bean.id)))
+
+		if (!bean.toggle) {
+			properties.add(minOnTime.bind(editor, beanIdProvider(bean.id)))
+		}
     }
 }

--- a/antares/shared/src/main/ch/scorpion/antares/model/input/Switch.kt
+++ b/antares/shared/src/main/ch/scorpion/antares/model/input/Switch.kt
@@ -42,7 +42,7 @@ class Switch : AbstractSwitch<Switch>(CALCULATOR) {
 	init {
 		addPort(DigitalPortImpl.createOutput())
 		propagationDelay = DEF_PROP_DELAY
-		minOnTime = DEF_PROP_DELAY * 5
+		minOnTime = 0
 	}
 
 	override val type: String get() = TYPE

--- a/antares/shared/src/main/ch/scorpion/antares/view/input/ImageSwitchView.kt
+++ b/antares/shared/src/main/ch/scorpion/antares/view/input/ImageSwitchView.kt
@@ -123,6 +123,12 @@ class ImageSwitchView(
             }
         }
 
+    var minOnTime: Long
+		get() = model.minOnTime
+		set(value) {
+			model.minOnTime = value
+		}
+
     @Suppress("unused") // Reflection
     var onImageId: ImageIdentification?
         get() = onImageData.value?.let { ImageIdentification(uuid = onImageUuid!!, name = it.name) }


### PR DESCRIPTION
This adds the new minOnTime to the new ImageSwitch and also sets the default to 0 to keep it compatible with previous versions.